### PR TITLE
Remove deprecated async-timeout synchronous context manager usage

### DIFF
--- a/adax/__init__.py
+++ b/adax/__init__.py
@@ -125,7 +125,7 @@ class Adax:
 
         headers = {"Authorization": f"Bearer {self._access_token}"}
         try:
-            with async_timeout.timeout(self._timeout):
+            async with async_timeout.timeout(self._timeout):
                 if json_data:
                     response = await self.websession.post(
                         url, json=json_data, headers=headers
@@ -164,7 +164,7 @@ class Adax:
 async def get_adax_token(websession, account_id, password, retry=3, timeout=10):
     """Get token for Adax."""
     try:
-        with async_timeout.timeout(timeout):
+        async with async_timeout.timeout(timeout):
             response = await websession.post(
                 f"{API_URL}/auth/token",
                 headers={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="adax",
     packages=["adax"],
-    install_requires=["aiohttp>=3.0.6", "async_timeout>=1.4.0"],
+    install_requires=["aiohttp>=3.0.6", "async_timeout>=3.0.0"],
     version="0.1.1",
     description="A python3 library to communicate with Adax",
     long_description="A python3 library to communicate with Adax",


### PR DESCRIPTION
Removes deprecated synchronous context manager usage for async-timeout.

This has been deprecated in 4.0.0 (which is now part of Home Assistant).
